### PR TITLE
🔨:[알림] FE 이슈대응 - 회원가입 버그 수정

### DIFF
--- a/src/main/java/com/sw/cmc/application/service/group/GroupService.java
+++ b/src/main/java/com/sw/cmc/application/service/group/GroupService.java
@@ -132,7 +132,7 @@ public class GroupService implements GroupUseCase {
         smtpUtil.sendEmailGroupInvite(invitee.getEmail(), inviter.getUsername(), group.getGroupName(), invitee.getUsername());
         // 인앱 알림
         Map<String, String> templateParams = Map.of("groupNm", group.getGroupName());
-        notiUtil.sendNotice(3L, "", templateParams);
+        notiUtil.sendNotice(inviter.getUserNum(),3L, "", templateParams);
 
         return messageUtil.getFormattedMessage("USER025");
     }

--- a/src/main/java/com/sw/cmc/application/service/user/JoinService.java
+++ b/src/main/java/com/sw/cmc/application/service/user/JoinService.java
@@ -1,5 +1,6 @@
 package com.sw.cmc.application.service.user;
 
+import com.sw.cmc.adapter.out.user.persistence.UserRepository;
 import com.sw.cmc.common.util.NotiUtil;
 import com.sw.cmc.common.util.SmtpUtil;
 import com.sw.cmc.common.util.UserUtil;
@@ -34,6 +35,7 @@ public class JoinService implements JoinUseCase {
     private final ModelMapper modelMapper;
     private final JoinRepository joinRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
 
     private final UserUtil userUtil;
     private final NotiUtil notiUtil;
@@ -72,8 +74,13 @@ public class JoinService implements JoinUseCase {
         // 가입 이메일 전송
         smtpUtil.sendEmailJoin(userDomain.getEmail(), userDomain.getUsername(), userDomain.getUserId(), userDomain.getPassword());
         // 가입 인앱 알림 전송
+        // 유저 정보 조회 해서 user id 구하기 ?
+
+        final User joinUser = userRepository.findByUsername(encryptedUserDomain.getUsername())
+                .orElseThrow(() -> new CmcException("USER001"));
+
         Map<String, String> templateParams = Map.of("userNm", userDomain.getUsername());
-        notiUtil.sendNotice(1L, "", templateParams);
+        notiUtil.sendNotice( joinUser.getUserNum(), 1L, "", templateParams);
 
         return encryptedUserDomain.toBuilder()
                 .resultMessage(messageUtil.getFormattedMessage("USER011"))

--- a/src/main/java/com/sw/cmc/common/util/NotiUtil.java
+++ b/src/main/java/com/sw/cmc/common/util/NotiUtil.java
@@ -23,11 +23,12 @@ public class NotiUtil {
     private final UserUtil userUtil;
     private final ApplicationEventPublisher eventPublisher;
 
-    public void sendNotice(Long notiTemplateId, String linkUrl , Map<String, String> templateParams) {
+    public void sendNotice(Long userNum, Long notiTemplateId, String linkUrl , Map<String, String> templateParams) {
         // 인앱 알림 (notice 테이블에 저장)
-        Long userNum = userUtil.getAuthenticatedUserNum();
+//        Long userNum = userUtil.getAuthenticatedUserNum();
 
         SendNotiInAppEvent sendNotiInAppEvent = SendNotiInAppEvent.builder()
+                .userNum(userNum)
                 .notiTemplateId(notiTemplateId)
                 .sendAt(LocalDateTime.now().toString())
                 .linkUrl(linkUrl)


### PR DESCRIPTION
회원가입시 알림 저장 오류 발생 원인은 user_num 필수인데 못가져옴 그래서 조회해서 가져옴 